### PR TITLE
add option to return custom fields

### DIFF
--- a/src/streamlit_plotly_events/__init__.py
+++ b/src/streamlit_plotly_events/__init__.py
@@ -51,6 +51,7 @@ def plotly_events(
     hover_event=False,
     override_height=450,
     override_width="100%",
+    return_fields=False,
     key=None,
 ):
     """Create a new instance of "plotly_events".
@@ -102,6 +103,7 @@ def plotly_events(
         click_event=click_event,
         select_event=select_event,
         hover_event=hover_event,
+        return_fields=return_fields,
         default="[]",  # Default return empty JSON list
     )
 

--- a/src/streamlit_plotly_events/frontend/package.json
+++ b/src/streamlit_plotly_events/frontend/package.json
@@ -11,12 +11,13 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "plotly.js": "^1.58.2",
+    "pretty-format": "^28.1.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-plotly.js": "^2.4.0",
     "react-scripts": "3.4.1",
     "streamlit-component-lib": "^1.2.0",
-    "typescript": "~3.7.2"
+    "typescript": "~3.8.0"
   },
   "devDependencies": {
     "@types/plotly.js": "^1.50.16",

--- a/src/streamlit_plotly_events/frontend/src/StreamlitPlotlyEventsComponent.tsx
+++ b/src/streamlit_plotly_events/frontend/src/StreamlitPlotlyEventsComponent.tsx
@@ -17,6 +17,7 @@ class StreamlitPlotlyEventsComponent extends StreamlitComponentBase {
     const click_event = this.props.args["click_event"];
     const select_event = this.props.args["select_event"];
     const hover_event = this.props.args["hover_event"];
+    
 
     Streamlit.setFrameHeight(override_height);
     return (
@@ -36,16 +37,22 @@ class StreamlitPlotlyEventsComponent extends StreamlitComponentBase {
 
   /** Click handler for plot. */
   private plotlyEventHandler = (data: any) => {
+    const return_fields = this.props.args["return_fields"];
+    
     // Build array of points to return
     var clickedPoints: Array<any> = [];
     data.points.forEach(function (arrayItem: any) {
-      clickedPoints.push({
-        x: arrayItem.x,
-        y: arrayItem.y,
-        curveNumber: arrayItem.curveNumber,
-        pointNumber: arrayItem.pointNumber,
-        pointIndex: arrayItem.pointIndex
-      })
+      let clickedPoint: any = {};
+      clickedPoint.x = arrayItem.x;
+      clickedPoint.y = arrayItem.y;
+      clickedPoint.pointNumber = arrayItem.pointNumber;
+      clickedPoint.pointIndex = arrayItem.pointIndex;
+      clickedPoint.curveNumber = arrayItem.curveNumber;
+      if (return_fields){
+        clickedPoint.customdata = arrayItem.customdata;
+      }
+
+      clickedPoints.push(clickedPoint);
     });
 
     // Return array as JSON to Streamlit


### PR DESCRIPTION
with this PR you can pass `return_fields=True` and get `custom_data/hover_data` return too.

Use Case:
pointIndex wasn't equal to the index of the dataframe in my case, that's why I needed to return some additional data about the selected point. can be useful for other cases too, like when you want to access more custom_data fields.

```
fig = px.scatter(df, x="x", y="y", color="type", hover_data=["index","index2"])

selected_points = plotly_events(fig,click_event=True,select_event=False,return_fields=True)
st.write(selected_points )
# customdata is an array because it didn't return a dict on the javascript side
0:{
"x":4.478600978851318
"y":-2.733484983444214
"pointNumber":181
"pointIndex":181
"curveNumber":0
"customdata":[
0:"5"
1:"10"
]
}
```

