### PR TITLE
Adding warning for stochastic data

### DIFF
--- a/src/streamlit_plotly_events/__init__.py
+++ b/src/streamlit_plotly_events/__init__.py
@@ -44,6 +44,7 @@ else:
 # `declare_component` and call it done. The wrapper allows us to customize
 # our component's API: we can pre-process its input args, post-process its
 # output value, and add a docstring for users.
+# Note: graph data must be deterministic, otherwise the event will return empty
 def plotly_events(
     plot_fig,
     click_event=True,


### PR DESCRIPTION
If graph data is different on every run of the streamlit program, a select event will not appear. Added a warning for this.

Sorry to create this pull request instead od an issue (couldn't see a place to do it).